### PR TITLE
Fix and extend

### DIFF
--- a/includes/event-payload.php
+++ b/includes/event-payload.php
@@ -20,7 +20,7 @@ class WP_Slack_Event_Payload {
 			'channel'      => $this->setting['channel'],
 			'username'     => $this->setting['username'],
 			'text'         => $this->setting['text'],
-			'icon_emoji'   => $this->setting['icon_emoji'],
+			'icon_url'     => $this->setting['icon_url'],
 
 			/**
 			 * @todo icon_emoji with ability to select it in setting.

--- a/includes/post-meta-box.php
+++ b/includes/post-meta-box.php
@@ -100,7 +100,8 @@ class WP_Slack_Post_Meta_Box {
 			'service_url' => 'esc_url',
 			'channel'     => 'sanitize_text_field',
 			'username'    => 'sanitize_text_field',
-			'icon_emoji'  => 'sanitize_text_field',
+			'icon_url'    => 'sanitize_text_field',
+			'category'		=> 'sanitize_text_field',
 			'active'      => function( $val ) {
 				if ( $val ) {
 					return true;
@@ -159,7 +160,7 @@ class WP_Slack_Post_Meta_Box {
 				'service_url' => esc_url( $_REQUEST['service_url'] ),
 				'channel'     => $_REQUEST['channel'],
 				'username'    => $_REQUEST['username'],
-				'icon_emoji'  => $_REQUEST['icon_emoji'],
+				'icon_url'  	=> $_REQUEST['icon_url'],
 				'text'        => __( 'Test sending payload!', 'slack' ),
 			);
 

--- a/includes/post-type.php
+++ b/includes/post-type.php
@@ -352,6 +352,7 @@ class WP_Slack_Post_Type {
 		$columns['service_url'] = __( 'Service URL', 'slack' );
 		$columns['channel']     = __( 'Channel', 'slack' );
 		$columns['bot_name']    = __( 'Bot Name', 'slack' );
+		$columns['category']    = __( 'Category Slug', 'slack');
 		$columns['events']      = __( 'Notified Events', 'slack' );
 
 		return $columns;
@@ -376,6 +377,9 @@ class WP_Slack_Post_Type {
 				break;
 			case 'bot_name':
 				echo ! empty( $setting['username'] ) ? $setting['username'] : '';
+				break;
+			case 'category':
+				echo ! empty( $setting['category'] ) ? $setting['category'] : '';
 				break;
 			case 'events':
 				$events = $this->plugin->event_manager->get_events();

--- a/js/admin.js
+++ b/js/admin.js
@@ -25,7 +25,8 @@
 				'service_url'      : $('[name="slack_setting[service_url]"]').val(),
 				'channel'          : $('[name="slack_setting[channel]"]').val(),
 				'username'         : $('[name="slack_setting[username]"]').val(),
-				'icon_emoji'       : $('[name="slack_setting[icon_emoji]"]').val(),
+				'icon_url'         : $('[name="slack_setting[icon_url]"]').val(),
+				'category'				 : $('[name="slack_setting[category]"]').cal(),
 				'test_notify_nonce': $('#slack-test-notify-nonce').val()
 			}
 		} );

--- a/views/post-meta-box.php
+++ b/views/post-meta-box.php
@@ -38,12 +38,26 @@
 
 		<tr valign="top">
 			<th scope="row">
-				<label for="slack_setting[icon_emoji]"><?php _e( 'Icon', 'slack' ); ?></label>
+				<label for="slack_setting[icon_url]"><?php _e( 'Icon', 'slack' ); ?></label>
 			</th>
 			<td>
-				<input type="text" class="regular-text" name="slack_setting[icon_emoji]" id="slack_setting[icon_emoji]" value="<?php echo ! empty( $setting['icon_emoji'] ) ? esc_attr( $setting['icon_emoji'] ) : ''; ?>">
+				<input type="text" class="regular-text" name="slack_setting[icon_url]" id="slack_setting[icon_url
+				]" value="<?php echo ! empty( $setting['icon_url'] ) ? esc_attr( $setting['icon_url'] ) : ''; ?>">
 				<p class="description">
-					<?php printf( __( 'Icon (short name) of the bot that delivers the notification. For available icon short name, see <a href="%s" target="blank" title="Emoji Catalog">here</a>. Short name must be wrapped with colon, for instance <code>:rocket:</code>.', 'slack' ), esc_url( 'http://unicodey.com/emoji-data/table.htm' ) ); ?>
+					<?php _e( 'Url to the icon of the bot to delivers the notification.', 'slack' ); ?>
+				</p>
+			</td>
+		</tr>
+
+		<tr valign="top">
+			<th scope="row">
+				<label for="slack_setting[category]"><?php _e( 'Category Slug', 'slack' ); ?></label>
+			</th>
+			<td>
+				<input type="text" class="regular-text" name="slack_setting[category]" id="slack_setting[category
+				]" value="<?php echo ! empty( $setting['category'] ) ? esc_attr( $setting['category'] ) : ''; ?>">
+				<p class="description">
+					<?php _e( 'The Post Category Slug that should trigger Slack notifications', 'slack' ); ?>
 				</p>
 			</td>
 		</tr>


### PR DESCRIPTION
Changelog:

* Fix bugs in current implementation
* Change Icon from emoji to url
* Add category slug to settings

I did some quick hacking this morning to make sure our thingy actually works. The major change is that I added a new setting where you can type in a Category slug that will be used to filter posts. This means we can ship this thing and then do final config in production when we have the details.

Obviously I have just ugly-hacked the plugin and not even tried to make som kind of extension without modifying the original plugin. Feel free to find a better way of implementing this! Optimally we should keep the plugin source unchanged.